### PR TITLE
Improve responsive layout and navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,20 @@
+.app-shell {
+  min-height: 100vh;
+  background: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-main {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 32px) clamp(16px, 5vw, 48px);
+  flex: 1;
+}
+
+@media (max-width: 600px) {
+  .app-main {
+    padding: 16px clamp(16px, 6vw, 24px);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,12 +17,13 @@ import LanguageForm from './routes/LanguageForm'
 import { TopNav } from './components/TopNav'
 import SignIn from './routes/SignIn'
 import RequireAuth from './auth/RequireAuth'
+import './App.css'
 
 function Shell() {
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--color-bg)' }}>
+    <div className="app-shell">
       <TopNav />
-      <main style={{ maxWidth: 960, margin: '0 auto', padding: '16px' }}>
+      <main className="app-main">
         <Outlet />
       </main>
     </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,7 +5,8 @@ export function Card({ children, style, onClick }: { children: ReactNode; style?
     background: 'var(--color-surface)',
     border: '1px solid var(--color-border)',
     borderRadius: 'var(--radius-lg)',
-    padding: '16px',
+    padding: 'clamp(12px, 3vw, 20px)',
+    width: '100%',
     cursor: onClick ? 'pointer' as const : 'default',
   }
   return (

--- a/src/components/TopNav.css
+++ b/src/components/TopNav.css
@@ -1,0 +1,83 @@
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  padding: 12px clamp(16px, 4vw, 24px);
+}
+
+.top-nav__content {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 960px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.top-nav__brand {
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: var(--font-xl);
+}
+
+.top-nav__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.top-nav__actions button,
+.top-nav__actions a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: var(--font-md);
+  cursor: pointer;
+}
+
+.top-nav__theme-toggle {
+  white-space: nowrap;
+}
+
+.top-nav__user-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.top-nav__user {
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+}
+
+@media (max-width: 600px) {
+  .top-nav__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .top-nav__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .top-nav__user-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,41 +1,32 @@
 import { Link } from 'react-router-dom'
 import { useTheme } from '../theme/useTheme'
 import { useAuth } from '../auth/AuthProvider'
+import './TopNav.css'
 
 export function TopNav() {
   const { theme, toggle } = useTheme()
   const { user, signOut } = useAuth()
   return (
-    <header
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '12px 16px',
-        borderBottom: '1px solid var(--color-border)',
-        position: 'sticky',
-        top: 0,
-        background: 'var(--color-bg)',
-        zIndex: 10,
-      }}
-    >
-      <Link to="/" style={{ color: 'var(--color-text)', textDecoration: 'none', fontWeight: 600 }}>
-        Story Collector
-      </Link>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <button onClick={toggle} style={{ background: 'transparent', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', padding: '6px 10px', color: 'var(--color-text)' }}>
-          Theme: {theme.name}
-        </button>
-        {user ? (
-          <>
-            <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)' }}>{user.email}</span>
-            <button onClick={signOut} style={{ background: 'transparent', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', padding: '6px 10px', color: 'var(--color-text)' }}>
-              Sign out
-            </button>
-          </>
-        ) : (
-          <Link to="/login" style={{ color: 'var(--color-text)' }}>Sign in</Link>
-        )}
+    <header className="top-nav">
+      <div className="top-nav__content">
+        <Link to="/" className="top-nav__brand">
+          Story Collector
+        </Link>
+        <div className="top-nav__actions">
+          <button type="button" onClick={toggle} className="top-nav__theme-toggle">
+            Theme: {theme.name}
+          </button>
+          {user ? (
+            <div className="top-nav__user-group">
+              <span className="top-nav__user">{user.email}</span>
+              <button type="button" onClick={signOut}>
+                Sign out
+              </button>
+            </div>
+          ) : (
+            <Link to="/login">Sign in</Link>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -31,8 +31,26 @@ body {
   color: var(--color-text);
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell,
     Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  line-height: 1.5;
 }
 
 a {
   color: var(--color-primary);
+}
+
+button {
+  font: inherit;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --font-sm: 11px;
+    --font-md: 13px;
+    --font-lg: 15px;
+    --font-xl: 20px;
+  }
+
+  body {
+    font-size: var(--font-lg);
+  }
 }

--- a/src/routes/CharacterForm.tsx
+++ b/src/routes/CharacterForm.tsx
@@ -241,7 +241,7 @@ export default function CharacterForm() {
       {charId ? null : <h1 style={{ color: 'var(--color-text)', margin: 0 }}>Add character</h1>}
       <Card>
         <div style={{ display: 'grid', gap: 12 }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
             <Avatar name={name} url={avatarUrl} size={56} editable onChange={setAvatarUrl} />
             <div style={{ flex: 1, display: 'grid', gap: 8 }}>
               <TextField label="Short name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
@@ -308,7 +308,7 @@ export default function CharacterForm() {
                 </Disclosure>
               )
             })}
-          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
             <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
               Cancel
             </Button>

--- a/src/routes/Characters.tsx
+++ b/src/routes/Characters.tsx
@@ -53,6 +53,8 @@ export default function Characters() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
         }}
       >
         <h1 style={{ margin: 0, color: "var(--color-text)" }}>Characters</h1>
@@ -96,10 +98,16 @@ export default function Characters() {
                     justifyContent: "space-between",
                     alignItems: "center",
                     gap: 12,
+                    flexWrap: "wrap",
                   }}
                 >
                   <div
-                    style={{ display: "flex", alignItems: "center", gap: 10 }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
                   >
                     <Avatar
                       name={c.name}
@@ -110,7 +118,7 @@ export default function Characters() {
                         /* no-op in list */
                       }}
                     />
-                    <div>
+                    <div style={{ minWidth: 0 }}>
                       <div
                         style={{ color: "var(--color-text)", fontWeight: 600 }}
                       >

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -7,18 +7,24 @@ export default function Dashboard() {
   const { stories } = useStories()
   return (
     <div style={{ display: 'grid', gap: 16 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
         <h1 style={{ margin: 0, color: 'var(--color-text)' }}>Your Stories</h1>
         <Link to="/stories/new"><Button>Create New Story</Button></Link>
       </div>
-      <div style={{ display: 'grid', gap: 12 }}>
+      <div
+        style={{
+          display: 'grid',
+          gap: 12,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+        }}
+      >
         {stories.length === 0 ? (
           <Card>
             <div style={{ color: 'var(--color-text-muted)' }}>No stories yet. Click "Create New Story" to begin.</div>
           </Card>
         ) : (
           stories.map((s) => (
-            <Link key={s.id} to={`/stories/${s.id}`} style={{ textDecoration: 'none' }}>
+            <Link key={s.id} to={`/stories/${s.id}`} style={{ textDecoration: 'none', display: 'block' }}>
               <Card>
                 <div style={{ color: 'var(--color-text)', fontWeight: 600 }}>{s.name}</div>
                 <div style={{ color: 'var(--color-text-muted)', marginTop: 4 }}>{s.shortDescription}</div>

--- a/src/routes/GroupForm.tsx
+++ b/src/routes/GroupForm.tsx
@@ -116,7 +116,7 @@ export default function GroupForm() {
       {elemId ? null : <h1 style={{ color: 'var(--color-text)', margin: 0 }}>Add group</h1>}
       <Card>
         <div style={{ display: 'grid', gap: 12 }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
             <Avatar name={name} url={avatarUrl} size={56} editable onChange={setAvatarUrl} />
             <div style={{ flex: 1, display: 'grid', gap: 8 }}>
               <TextField label="Name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
@@ -159,7 +159,7 @@ export default function GroupForm() {
             )
           })}
 
-          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
             <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
               Cancel
             </Button>

--- a/src/routes/Groups.tsx
+++ b/src/routes/Groups.tsx
@@ -63,6 +63,8 @@ export default function Groups() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
         }}
       >
         <h1 style={{ margin: 0, color: "var(--color-text)" }}>Groups</h1>
@@ -107,10 +109,17 @@ export default function Groups() {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
                   }}
                 >
                   <div
-                    style={{ display: "flex", alignItems: "center", gap: 10 }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
                   >
                     <Avatar
                       name={el.name}
@@ -119,7 +128,7 @@ export default function Groups() {
                       editable={false}
                       onChange={() => {}}
                     />
-                    <div>
+                    <div style={{ minWidth: 0 }}>
                       <div
                         style={{ color: "var(--color-text)", fontWeight: 600 }}
                       >
@@ -137,7 +146,7 @@ export default function Groups() {
                       ) : null}
                     </div>
                   </div>
-                  <div style={{ display: "flex", gap: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {storyId ? (
                       <a
                         href={`/stories/${storyId}/groups/${el.id}/edit`}

--- a/src/routes/LanguageForm.tsx
+++ b/src/routes/LanguageForm.tsx
@@ -76,7 +76,7 @@ export default function LanguageForm() {
       {elemId ? null : <h1 style={{ color: 'var(--color-text)', margin: 0 }}>Add language</h1>}
       <Card>
         <div style={{ display: 'grid', gap: 12 }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
             <Avatar name={name} url={avatarUrl} size={56} editable onChange={setAvatarUrl} />
             <div style={{ flex: 1, display: 'grid', gap: 8 }}>
               <TextField label="Name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
@@ -87,7 +87,7 @@ export default function LanguageForm() {
             <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)', marginBottom: 6 }}>Long description</div>
             <MentionArea value={longDesc} onChange={setLongDesc} suggestions={suggestions} />
           </div>
-          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
             <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
               Cancel
             </Button>

--- a/src/routes/Languages.tsx
+++ b/src/routes/Languages.tsx
@@ -67,6 +67,8 @@ export default function Languages() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
         }}
       >
         <h1 style={{ margin: 0, color: "var(--color-text)" }}>Languages</h1>
@@ -111,10 +113,17 @@ export default function Languages() {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
                   }}
                 >
                   <div
-                    style={{ display: "flex", alignItems: "center", gap: 10 }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
                   >
                     <Avatar
                       name={el.name}
@@ -123,7 +132,7 @@ export default function Languages() {
                       editable={false}
                       onChange={() => {}}
                     />
-                    <div>
+                    <div style={{ minWidth: 0 }}>
                       <div
                         style={{ color: "var(--color-text)", fontWeight: 600 }}
                       >
@@ -141,7 +150,7 @@ export default function Languages() {
                       ) : null}
                     </div>
                   </div>
-                  <div style={{ display: "flex", gap: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {storyId ? (
                       <a
                         href={`/stories/${storyId}/languages/${el.id}/edit`}

--- a/src/routes/LocationForm.tsx
+++ b/src/routes/LocationForm.tsx
@@ -80,7 +80,7 @@ export default function LocationForm() {
       {elemId ? null : <h1 style={{ color: 'var(--color-text)', margin: 0 }}>Add location</h1>}
       <Card>
         <div style={{ display: 'grid', gap: 12 }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
             <Avatar name={name} url={avatarUrl} size={56} editable onChange={setAvatarUrl} />
             <div style={{ flex: 1, display: 'grid', gap: 8 }}>
               <TextField label="Name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
@@ -119,7 +119,7 @@ export default function LocationForm() {
             )
           })}
 
-          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
             <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
               Cancel
             </Button>

--- a/src/routes/Locations.tsx
+++ b/src/routes/Locations.tsx
@@ -67,6 +67,8 @@ export default function Locations() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
         }}
       >
         <h1 style={{ margin: 0, color: "var(--color-text)" }}>Locations</h1>
@@ -111,10 +113,17 @@ export default function Locations() {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
                   }}
                 >
                   <div
-                    style={{ display: "flex", alignItems: "center", gap: 10 }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
                   >
                     <Avatar
                       name={el.name}
@@ -123,7 +132,7 @@ export default function Locations() {
                       editable={false}
                       onChange={() => {}}
                     />
-                    <div>
+                    <div style={{ minWidth: 0 }}>
                       <div
                         style={{ color: "var(--color-text)", fontWeight: 600 }}
                       >
@@ -141,7 +150,7 @@ export default function Locations() {
                       ) : null}
                     </div>
                   </div>
-                  <div style={{ display: "flex", gap: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {storyId ? (
                       <a
                         href={`/stories/${storyId}/locations/${el.id}/edit`}

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -39,7 +39,7 @@ export default function SignIn() {
         padding: 16,
       }}
     >
-      <Card style={{ width: 360 }}>
+      <Card style={{ width: '100%', maxWidth: 360 }}>
         <h1 style={{ marginTop: 0, color: "var(--color-text)" }}>Sign in</h1>
         <form onSubmit={onSubmit} style={{ display: "grid", gap: 12 }}>
           <TextField

--- a/src/routes/Species.tsx
+++ b/src/routes/Species.tsx
@@ -50,6 +50,8 @@ export default function Species() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          flexWrap: "wrap",
+          gap: 12,
         }}
       >
         <h1 style={{ margin: 0, color: "var(--color-text)" }}>Species</h1>
@@ -94,10 +96,17 @@ export default function Species() {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
                   }}
                 >
                   <div
-                    style={{ display: "flex", alignItems: "center", gap: 10 }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                    }}
                   >
                     <Avatar
                       name={el.name}
@@ -106,7 +115,7 @@ export default function Species() {
                       editable={false}
                       onChange={() => {}}
                     />
-                    <div>
+                    <div style={{ minWidth: 0 }}>
                       <div
                         style={{ color: "var(--color-text)", fontWeight: 600 }}
                       >
@@ -124,7 +133,7 @@ export default function Species() {
                       ) : null}
                     </div>
                   </div>
-                  <div style={{ display: "flex", gap: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {storyId ? (
                       <a
                         href={`/stories/${storyId}/species/${el.id}/edit`}

--- a/src/routes/SpeciesForm.tsx
+++ b/src/routes/SpeciesForm.tsx
@@ -76,7 +76,7 @@ export default function SpeciesForm() {
       {elemId ? null : <h1 style={{ color: 'var(--color-text)', margin: 0 }}>Add species</h1>}
       <Card>
         <div style={{ display: 'grid', gap: 12 }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
             <Avatar name={name} url={avatarUrl} size={56} editable onChange={setAvatarUrl} />
             <div style={{ flex: 1, display: 'grid', gap: 8 }}>
               <TextField label="Name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
@@ -87,7 +87,7 @@ export default function SpeciesForm() {
             <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--font-sm)', marginBottom: 6 }}>Long description</div>
             <MentionArea value={longDesc} onChange={setLongDesc} suggestions={suggestions} />
           </div>
-          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
             <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
               Cancel
             </Button>

--- a/src/routes/StoryForm.tsx
+++ b/src/routes/StoryForm.tsx
@@ -60,7 +60,14 @@ export default function StoryForm() {
             }
             maxChars={MAX_DESC}
           />
-          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              justifyContent: "flex-end",
+              flexWrap: "wrap",
+            }}
+          >
             <Button
               variant="ghost"
               type="button"

--- a/src/routes/StoryView.tsx
+++ b/src/routes/StoryView.tsx
@@ -16,7 +16,7 @@ export default function StoryView() {
 
   return (
     <div style={{ display: 'grid', gap: 16 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
         <h1 style={{ margin: 0, color: 'var(--color-text)' }}>{story.name}</h1>
         <IconButton aria-label="Edit story" onClick={() => navigate(`/stories/${story.id}/edit`)} title="Edit">
           ✏️
@@ -29,7 +29,8 @@ export default function StoryView() {
             try {
               await remove(id)
               navigate('/')
-            } catch (e) {
+            } catch (error) {
+              console.error('Failed to delete story', error)
               alert('Failed to delete story')
             }
           }}


### PR DESCRIPTION
## Summary
- add shared layout styles so the shell and main content scale cleanly on smaller screens
- restyle the top navigation with a responsive layout that wraps controls and keeps content aligned
- allow story lists, detail headers, and forms to wrap and space controls for better usability on mobile

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1e2acba38833196e763afc770a154