### PR TITLE
Add habit notification scheduling page and settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import SpeciesForm from './routes/SpeciesForm'
 import LocationForm from './routes/LocationForm'
 import GroupForm from './routes/GroupForm'
 import LanguageForm from './routes/LanguageForm'
+import HabitNotifications from './routes/HabitNotifications'
 import { TopNav } from './components/TopNav'
 import SignIn from './routes/SignIn'
 import RequireAuth from './auth/RequireAuth'
@@ -33,11 +34,12 @@ function Shell() {
 export default function App() {
   return (
     <Routes>
-      <Route path="/login" element={<SignIn />} />
-      <Route element={<RequireAuth />}>
-        <Route element={<Shell />}>
-          <Route index element={<Dashboard />} />
-          <Route path="stories">
+          <Route path="/login" element={<SignIn />} />
+          <Route element={<RequireAuth />}>
+            <Route element={<Shell />}>
+              <Route index element={<Dashboard />} />
+              <Route path="notifications/habits" element={<HabitNotifications />} />
+              <Route path="stories">
             <Route path="new" element={<StoryForm />} />
             <Route path=":id" element={<StoryView />} />
             <Route path=":id/edit" element={<StoryForm />} />

--- a/src/components/TopNav.css
+++ b/src/components/TopNav.css
@@ -25,6 +25,41 @@
   font-size: var(--font-xl);
 }
 
+.top-nav__brand-group {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.top-nav__links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.top-nav__link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: var(--font-md);
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.top-nav__link:hover {
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+.top-nav__link--active {
+  color: var(--color-text);
+  border-color: var(--color-border);
+  background: var(--color-surface);
+}
+
 .top-nav__actions {
   display: flex;
   align-items: center;
@@ -69,6 +104,15 @@
   .top-nav__content {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .top-nav__brand-group {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .top-nav__links {
+    width: 100%;
   }
 
   .top-nav__actions {

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 import { useTheme } from '../theme/useTheme'
 import { useAuth } from '../auth/AuthProvider'
 import './TopNav.css'
@@ -6,12 +6,34 @@ import './TopNav.css'
 export function TopNav() {
   const { theme, toggle } = useTheme()
   const { user, signOut } = useAuth()
+  const navLinks = [
+    { to: '/', label: 'Dashboard' },
+    { to: '/notifications/habits', label: 'Notifications' },
+  ]
   return (
     <header className="top-nav">
       <div className="top-nav__content">
-        <Link to="/" className="top-nav__brand">
-          Story Collector
-        </Link>
+        <div className="top-nav__brand-group">
+          <Link to="/" className="top-nav__brand">
+            Story Collector
+          </Link>
+          <nav className="top-nav__links">
+            {navLinks.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                end={link.to === '/'}
+                className={({ isActive }) =>
+                  ['top-nav__link', isActive ? 'top-nav__link--active' : undefined]
+                    .filter(Boolean)
+                    .join(' ')
+                }
+              >
+                {link.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
         <div className="top-nav__actions">
           <button type="button" onClick={toggle} className="top-nav__theme-toggle">
             Theme: {theme.name}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,56 @@
+import {
+  NOTIFICATION_CATEGORY_VALUES,
+  TIME_OF_DAY_VALUES,
+  WEEKDAY_VALUES,
+  type NotificationCategory,
+  type TimeOfDayOption,
+  type Weekday,
+} from '../types/notifications'
+
+export const NOTIFICATION_CATEGORY_LABELS: Record<NotificationCategory, string> = {
+  habitReminders: 'Habit reminders',
+  progressUpdates: 'Progress updates',
+  streakCelebrations: 'Streak celebrations',
+  goalAchievements: 'Goal achievements',
+}
+
+export const NOTIFICATION_CATEGORY_DESCRIPTIONS: Record<NotificationCategory, string> = {
+  habitReminders: 'Get reminders to complete the habits on your schedule.',
+  progressUpdates: 'Stay informed about your overall progress (coming soon).',
+  streakCelebrations: 'Celebrate important streak milestones (coming soon).',
+  goalAchievements: 'Be notified when major goals are achieved (coming soon).',
+}
+
+export const TIME_OF_DAY_LABELS: Record<TimeOfDayOption, string> = {
+  morning: 'Morning',
+  afternoon: 'Afternoon',
+  evening: 'Evening',
+}
+
+export const WEEKDAY_LABELS: Record<Weekday, string> = {
+  monday: 'Monday',
+  tuesday: 'Tuesday',
+  wednesday: 'Wednesday',
+  thursday: 'Thursday',
+  friday: 'Friday',
+  saturday: 'Saturday',
+  sunday: 'Sunday',
+}
+
+export function isNotificationCategory(value: unknown): value is NotificationCategory {
+  return NOTIFICATION_CATEGORY_VALUES.includes(value as NotificationCategory)
+}
+
+export function isTimeOfDay(value: unknown): value is TimeOfDayOption {
+  return TIME_OF_DAY_VALUES.includes(value as TimeOfDayOption)
+}
+
+export function isWeekday(value: unknown): value is Weekday {
+  return WEEKDAY_VALUES.includes(value as Weekday)
+}
+
+export function sortWeekdays(days: Weekday[]): Weekday[] {
+  const order = [...WEEKDAY_VALUES]
+  const unique = Array.from(new Set(days)) as Weekday[]
+  return order.filter((day) => unique.includes(day))
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,9 @@ import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from './theme/ThemeProvider'
 import { BrowserRouter } from 'react-router-dom'
-import { StoriesProvider } from './state/StoriesProvider'
 import { AuthProvider } from './auth/AuthProvider'
+import { StoriesProvider } from './state/StoriesProvider'
+import { NotificationSettingsProvider } from './state/NotificationSettingsProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -13,7 +14,9 @@ createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <AuthProvider>
           <StoriesProvider>
-            <App />
+            <NotificationSettingsProvider>
+              <App />
+            </NotificationSettingsProvider>
           </StoriesProvider>
         </AuthProvider>
       </BrowserRouter>

--- a/src/routes/HabitNotifications.tsx
+++ b/src/routes/HabitNotifications.tsx
@@ -1,0 +1,340 @@
+import { useMemo } from 'react'
+import { Card } from '../components/Card'
+import {
+  NOTIFICATION_CATEGORY_VALUES,
+  TIME_OF_DAY_VALUES,
+  WEEKDAY_VALUES,
+  type HabitNotificationPreference,
+  type HabitNotificationSchedule,
+  type TimeOfDayOption,
+  type Weekday,
+} from '../types/notifications'
+import {
+  NOTIFICATION_CATEGORY_DESCRIPTIONS,
+  NOTIFICATION_CATEGORY_LABELS,
+  TIME_OF_DAY_LABELS,
+  WEEKDAY_LABELS,
+  sortWeekdays,
+} from '../lib/notifications'
+import { useNotificationSettings } from '../state/NotificationSettingsProvider'
+
+type Habit = {
+  id: string
+  name: string
+  description?: string
+}
+
+const DEFAULT_CUSTOM_TIME = '09:00'
+
+const HABITS: Habit[] = [
+  {
+    id: 'hydrate',
+    name: 'Drink water',
+    description: 'Stay hydrated by drinking a glass of water.',
+  },
+  {
+    id: 'journal',
+    name: 'Morning journal',
+    description: 'Capture your thoughts with a quick journal entry.',
+  },
+  {
+    id: 'stretch',
+    name: 'Stretch break',
+    description: 'Take a mindful stretch to reset your posture.',
+  },
+]
+
+type ScheduleType = HabitNotificationSchedule['type']
+
+function ensureSchedule(
+  schedule: HabitNotificationSchedule | undefined,
+  type: ScheduleType,
+): HabitNotificationSchedule {
+  if (type === 'timeOfDay') {
+    return {
+      type: 'timeOfDay',
+      timeOfDay:
+        schedule?.type === 'timeOfDay' ? schedule.timeOfDay : TIME_OF_DAY_VALUES[0],
+    }
+  }
+  const fallbackDays = [...WEEKDAY_VALUES]
+  const days =
+    schedule?.type === 'exact' && schedule.daysOfWeek.length
+      ? sortWeekdays(schedule.daysOfWeek)
+      : fallbackDays
+  const time = schedule?.type === 'exact' ? schedule.time : DEFAULT_CUSTOM_TIME
+  return { type: 'exact', time, daysOfWeek: days }
+}
+
+function HabitScheduleCard({
+  habit,
+  preference,
+  onChange,
+  disabled,
+}: {
+  habit: Habit
+  preference?: HabitNotificationPreference
+  onChange: (update: Partial<HabitNotificationPreference>) => void
+  disabled: boolean
+}) {
+  const enabled = preference?.enabled ?? false
+  const schedule = preference?.schedule
+  const scheduleType: ScheduleType = schedule?.type ?? 'timeOfDay'
+
+  const handleEnabledChange = (next: boolean) => {
+    if (next) {
+      const nextSchedule = ensureSchedule(schedule, scheduleType)
+      onChange({ enabled: true, schedule: nextSchedule })
+    } else {
+      onChange({ enabled: false, schedule: undefined })
+    }
+  }
+
+  const handleScheduleTypeChange = (nextType: ScheduleType) => {
+    const nextSchedule = ensureSchedule(schedule, nextType)
+    onChange({ enabled: true, schedule: nextSchedule })
+  }
+
+  const handleTimeOfDayChange = (value: TimeOfDayOption) => {
+    onChange({
+      enabled: true,
+      schedule: { type: 'timeOfDay', timeOfDay: value },
+    })
+  }
+
+  const handleCustomTimeChange = (value: string) => {
+    const timeValue = value || DEFAULT_CUSTOM_TIME
+    const current = ensureSchedule(schedule, 'exact')
+    onChange({
+      enabled: true,
+      schedule: { type: 'exact', time: timeValue, daysOfWeek: current.daysOfWeek },
+    })
+  }
+
+  const handleDayToggle = (day: Weekday) => {
+    const current = ensureSchedule(schedule, 'exact')
+    const set = new Set(current.daysOfWeek)
+    if (set.has(day)) {
+      if (set.size === 1) {
+        return
+      }
+      set.delete(day)
+    } else {
+      set.add(day)
+    }
+    const nextDays = sortWeekdays(Array.from(set) as Weekday[])
+    onChange({
+      enabled: true,
+      schedule: { type: 'exact', time: current.time, daysOfWeek: nextDays },
+    })
+  }
+
+  const scheduleDisabled = disabled || !enabled
+
+  return (
+    <Card>
+      <div style={{ display: 'grid', gap: 12 }}>
+        <div>
+          <div style={{ fontWeight: 600, color: 'var(--color-text)' }}>{habit.name}</div>
+          {habit.description ? (
+            <div style={{ color: 'var(--color-text-muted)', marginTop: 4 }}>
+              {habit.description}
+            </div>
+          ) : null}
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => handleEnabledChange(event.target.checked)}
+            disabled={disabled}
+          />
+          <span>Enable reminders</span>
+        </label>
+        <div style={{ display: 'grid', gap: 8 }}>
+          <div style={{ fontWeight: 500 }}>Schedule type</div>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <input
+                type="radio"
+                name={`${habit.id}-schedule`}
+                value="timeOfDay"
+                checked={scheduleType === 'timeOfDay'}
+                onChange={() => handleScheduleTypeChange('timeOfDay')}
+                disabled={scheduleDisabled}
+              />
+              <span>Time of day</span>
+            </label>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <input
+                type="radio"
+                name={`${habit.id}-schedule`}
+                value="exact"
+                checked={scheduleType === 'exact'}
+                onChange={() => handleScheduleTypeChange('exact')}
+                disabled={scheduleDisabled}
+              />
+              <span>Specific time</span>
+            </label>
+          </div>
+        </div>
+        {scheduleType === 'timeOfDay' ? (
+          <div style={{ display: 'grid', gap: 6 }}>
+            <div style={{ fontWeight: 500 }}>Reminder window</div>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              {TIME_OF_DAY_VALUES.map((value) => (
+                <label key={value} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <input
+                    type="radio"
+                    name={`${habit.id}-timeOfDay`}
+                    value={value}
+                    checked={schedule?.type === 'timeOfDay' ? schedule.timeOfDay === value : value === TIME_OF_DAY_VALUES[0]}
+                    onChange={() => handleTimeOfDayChange(value)}
+                    disabled={scheduleDisabled}
+                  />
+                  <span>{TIME_OF_DAY_LABELS[value]}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ fontWeight: 500 }}>Reminder time</div>
+              <input
+                type="time"
+                value={schedule?.type === 'exact' ? schedule.time : DEFAULT_CUSTOM_TIME}
+                onChange={(event) => handleCustomTimeChange(event.target.value)}
+                disabled={scheduleDisabled}
+              />
+            </div>
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ fontWeight: 500 }}>Days of the week</div>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                {WEEKDAY_VALUES.map((day) => {
+                  const selected = schedule?.type === 'exact' ? schedule.daysOfWeek.includes(day) : true
+                  return (
+                    <label key={day} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={() => handleDayToggle(day)}
+                        disabled={scheduleDisabled}
+                      />
+                      <span>{WEEKDAY_LABELS[day]}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+export default function HabitNotifications() {
+  const {
+    globalEnabled,
+    categories,
+    habitPreferences,
+    setGlobalEnabled,
+    setCategoryEnabled,
+    setHabitPreference,
+  } = useNotificationSettings()
+
+  const remindersDisabled = !globalEnabled || !categories.habitReminders
+  const categoryItems = useMemo(() => {
+    return NOTIFICATION_CATEGORY_VALUES.map((category) => ({
+      id: category,
+      label: NOTIFICATION_CATEGORY_LABELS[category],
+      description: NOTIFICATION_CATEGORY_DESCRIPTIONS[category],
+    }))
+  }, [])
+
+  return (
+    <div style={{ display: 'grid', gap: 24 }}>
+      <div style={{ display: 'grid', gap: 12 }}>
+        <h1 style={{ margin: 0 }}>Notifications</h1>
+        <p style={{ margin: 0, color: 'var(--color-text-muted)' }}>
+          Configure when Story Collector should send you habit reminders.
+        </p>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={globalEnabled}
+            onChange={(event) => setGlobalEnabled(event.target.checked)}
+          />
+          <span>Enable notifications</span>
+        </label>
+      </div>
+      <Card>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <div>
+            <div style={{ fontWeight: 600, color: 'var(--color-text)' }}>Notification categories</div>
+            <div style={{ color: 'var(--color-text-muted)', marginTop: 4 }}>
+              Choose the types of notifications you want to receive. Only habit reminders are
+              available right now.
+            </div>
+          </div>
+          <div style={{ display: 'grid', gap: 12 }}>
+            {categoryItems.map((category) => (
+              <label key={category.id} style={{ display: 'grid', gap: 4 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="checkbox"
+                    checked={categories[category.id] ?? false}
+                    onChange={(event) =>
+                      setCategoryEnabled(category.id, event.target.checked)
+                    }
+                    disabled={!globalEnabled}
+                  />
+                  <span style={{ fontWeight: 500 }}>{category.label}</span>
+                </div>
+                <span style={{ color: 'var(--color-text-muted)' }}>{category.description}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      </Card>
+      <div style={{ display: 'grid', gap: 16 }}>
+        <div>
+          <div style={{ fontWeight: 600, color: 'var(--color-text)' }}>Habit reminders</div>
+          <div style={{ color: 'var(--color-text-muted)', marginTop: 4 }}>
+            Set personalised schedules for each habit. Reminders follow the global and category
+            settings above.
+          </div>
+          {remindersDisabled ? (
+            <div style={{ color: 'var(--color-text-muted)', marginTop: 8 }}>
+              Enable notifications and the habit reminders category to customise schedules.
+            </div>
+          ) : null}
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gap: 16,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          }}
+        >
+          {HABITS.map((habit) => (
+            <HabitScheduleCard
+              key={habit.id}
+              habit={habit}
+              preference={habitPreferences[habit.id]}
+              onChange={(update) =>
+                setHabitPreference(habit.id, {
+                  enabled: update.enabled,
+                  schedule: update.schedule ?? null,
+                })
+              }
+              disabled={remindersDisabled}
+            />
+          ))}
+        </div>
+      </div>
+      <div style={{ color: 'var(--color-text-muted)' }}>Changes save automatically.</div>
+    </div>
+  )
+}

--- a/src/state/NotificationSettingsProvider.tsx
+++ b/src/state/NotificationSettingsProvider.tsx
@@ -1,0 +1,252 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  NOTIFICATION_CATEGORY_VALUES,
+  type HabitNotificationPreference,
+  type HabitNotificationSchedule,
+  type NotificationCategory,
+  type Weekday,
+  type NotificationSettingsState,
+} from '../types/notifications'
+import {
+  isTimeOfDay,
+  isWeekday,
+  sortWeekdays,
+} from '../lib/notifications'
+
+const STORAGE_KEY = 'notification-settings:v1'
+
+const DEFAULT_CATEGORY_STATE: Record<NotificationCategory, boolean> = {
+  habitReminders: true,
+  progressUpdates: false,
+  streakCelebrations: false,
+  goalAchievements: false,
+}
+
+function createDefaultState(): NotificationSettingsState {
+  return {
+    global: {
+      enabled: true,
+      categories: { ...DEFAULT_CATEGORY_STATE },
+    },
+    habitPreferences: {},
+  }
+}
+
+type HabitPreferenceUpdate = {
+  enabled?: boolean
+  schedule?: HabitNotificationSchedule | null
+}
+
+type NotificationSettingsContextValue = {
+  globalEnabled: boolean
+  categories: Record<NotificationCategory, boolean>
+  habitPreferences: Record<string, HabitNotificationPreference>
+  setGlobalEnabled: (enabled: boolean) => void
+  setCategoryEnabled: (category: NotificationCategory, enabled: boolean) => void
+  setHabitPreference: (habitId: string, update: HabitPreferenceUpdate) => void
+  clearHabitPreference: (habitId: string) => void
+}
+
+const NotificationSettingsContext = createContext<NotificationSettingsContextValue | undefined>(
+  undefined,
+)
+
+function loadState(): NotificationSettingsState {
+  if (typeof window === 'undefined') {
+    return createDefaultState()
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return createDefaultState()
+    const parsed = JSON.parse(raw) as unknown
+    return normalizeState(parsed)
+  } catch {
+    return createDefaultState()
+  }
+}
+
+function normalizeState(raw: unknown): NotificationSettingsState {
+  const base = createDefaultState()
+  if (!raw || typeof raw !== 'object') {
+    return base
+  }
+
+  const globalRaw = (raw as Record<string, unknown>).global
+  const globalObject =
+    globalRaw && typeof globalRaw === 'object' ? (globalRaw as Record<string, unknown>) : {}
+  const categoriesRaw =
+    globalObject.categories && typeof globalObject.categories === 'object'
+      ? (globalObject.categories as Record<string, unknown>)
+      : {}
+  const categories = { ...DEFAULT_CATEGORY_STATE }
+  for (const category of NOTIFICATION_CATEGORY_VALUES) {
+    const value = categoriesRaw[category]
+    if (typeof value === 'boolean') {
+      categories[category] = value
+    }
+  }
+
+  const habitPreferences: Record<string, HabitNotificationPreference> = {}
+  const preferencesRaw = (raw as Record<string, unknown>).habitPreferences
+  if (preferencesRaw && typeof preferencesRaw === 'object') {
+    for (const [habitId, pref] of Object.entries(preferencesRaw as Record<string, unknown>)) {
+      const normalized = normalizeHabitPreference(habitId, pref)
+      if (normalized) {
+        habitPreferences[habitId] = normalized
+      }
+    }
+  }
+
+  return {
+    global: {
+      enabled: typeof globalObject.enabled === 'boolean' ? globalObject.enabled : base.global.enabled,
+      categories,
+    },
+    habitPreferences,
+  }
+}
+
+function normalizeHabitPreference(
+  habitId: string,
+  raw: unknown,
+): HabitNotificationPreference | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+  const prefObject = raw as Record<string, unknown>
+  const enabled = typeof prefObject.enabled === 'boolean' ? prefObject.enabled : false
+  const schedule = normalizeSchedule(prefObject.schedule)
+  if (!enabled && !schedule) {
+    return null
+  }
+  const preference: HabitNotificationPreference = { habitId, enabled }
+  if (schedule) {
+    preference.schedule = schedule
+  }
+  return preference
+}
+
+function normalizeSchedule(raw: unknown): HabitNotificationSchedule | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined
+  }
+  const schedule = raw as Record<string, unknown>
+  const type = schedule.type
+  if (type === 'timeOfDay' && isTimeOfDay(schedule.timeOfDay)) {
+    return { type: 'timeOfDay', timeOfDay: schedule.timeOfDay }
+  }
+  if (type === 'exact') {
+    const time = typeof schedule.time === 'string' ? schedule.time : ''
+    const days = Array.isArray(schedule.daysOfWeek)
+      ? sortWeekdays(schedule.daysOfWeek.filter((d): d is Weekday => isWeekday(d)))
+      : []
+    if (time && days.length > 0) {
+      return { type: 'exact', time, daysOfWeek: days }
+    }
+  }
+  return undefined
+}
+
+export function NotificationSettingsProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<NotificationSettingsState>(() => loadState())
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    } catch {
+      // ignore persistence failures
+    }
+  }, [state])
+
+  const value = useMemo<NotificationSettingsContextValue>(() => {
+    const setGlobalEnabled = (enabled: boolean) => {
+      setState((prev) => ({
+        ...prev,
+        global: { ...prev.global, enabled },
+      }))
+    }
+
+    const setCategoryEnabled = (category: NotificationCategory, enabled: boolean) => {
+      setState((prev) => ({
+        ...prev,
+        global: {
+          ...prev.global,
+          categories: { ...prev.global.categories, [category]: enabled },
+        },
+      }))
+    }
+
+    const setHabitPreference = (habitId: string, update: HabitPreferenceUpdate) => {
+      setState((prev) => {
+        const existing = prev.habitPreferences[habitId]
+        const next: HabitNotificationPreference = {
+          habitId,
+          enabled: existing?.enabled ?? false,
+          ...(existing?.schedule ? { schedule: existing.schedule } : {}),
+        }
+        if (typeof update.enabled === 'boolean') {
+          next.enabled = update.enabled
+        }
+        if (update.schedule === null) {
+          delete next.schedule
+        } else if (update.schedule) {
+          next.schedule = update.schedule
+        }
+        if (!next.enabled && !next.schedule) {
+          const rest = { ...prev.habitPreferences }
+          delete rest[habitId]
+          return { ...prev, habitPreferences: rest }
+        }
+        return {
+          ...prev,
+          habitPreferences: {
+            ...prev.habitPreferences,
+            [habitId]: next,
+          },
+        }
+      })
+    }
+
+    const clearHabitPreference = (habitId: string) => {
+      setState((prev) => {
+        if (!prev.habitPreferences[habitId]) {
+          return prev
+        }
+        const rest = { ...prev.habitPreferences }
+        delete rest[habitId]
+        return { ...prev, habitPreferences: rest }
+      })
+    }
+
+    return {
+      globalEnabled: state.global.enabled,
+      categories: state.global.categories,
+      habitPreferences: state.habitPreferences,
+      setGlobalEnabled,
+      setCategoryEnabled,
+      setHabitPreference,
+      clearHabitPreference,
+    }
+  }, [state])
+
+  return (
+    <NotificationSettingsContext.Provider value={value}>
+      {children}
+    </NotificationSettingsContext.Provider>
+  )
+}
+
+export function useNotificationSettings() {
+  const ctx = useContext(NotificationSettingsContext)
+  if (!ctx) {
+    throw new Error('useNotificationSettings must be used within NotificationSettingsProvider')
+  }
+  return ctx
+}

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,51 @@
+export const NOTIFICATION_CATEGORY_VALUES = [
+  'habitReminders',
+  'progressUpdates',
+  'streakCelebrations',
+  'goalAchievements',
+] as const
+
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORY_VALUES)[number]
+
+export const TIME_OF_DAY_VALUES = ['morning', 'afternoon', 'evening'] as const
+
+export type TimeOfDayOption = (typeof TIME_OF_DAY_VALUES)[number]
+
+export const WEEKDAY_VALUES = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const
+
+export type Weekday = (typeof WEEKDAY_VALUES)[number]
+
+export type NotificationGlobalSettings = {
+  enabled: boolean
+  categories: Record<NotificationCategory, boolean>
+}
+
+export type HabitNotificationSchedule =
+  | {
+      type: 'timeOfDay'
+      timeOfDay: TimeOfDayOption
+    }
+  | {
+      type: 'exact'
+      time: string
+      daysOfWeek: Weekday[]
+    }
+
+export type HabitNotificationPreference = {
+  habitId: string
+  enabled: boolean
+  schedule?: HabitNotificationSchedule
+}
+
+export type NotificationSettingsState = {
+  global: NotificationGlobalSettings
+  habitPreferences: Record<string, HabitNotificationPreference>
+}


### PR DESCRIPTION
## Summary
- add a notification settings provider that persists global toggles and per-habit schedules
- share notification category, time of day, and weekday helpers for future notification types
- expose a habit notifications settings route with navigation entry and scheduling controls

## Testing
- npm run lint *(fails: existing lint errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6aa4986b48331a6b4d31e2e4899a9